### PR TITLE
Fix incorrect CLI descriptions

### DIFF
--- a/pickle
+++ b/pickle
@@ -31,9 +31,9 @@ $app->command('initialize [--context=] relative_feature_file_path', function (
 
 })->defaults([
     'context' => "domain"
-])->descriptions("This will stuff out your feature into a Dusk Test file",
+])->descriptions("This will stub out your feature into a Dusk Test file",
     [
-        '--context' => "domain or ui this will help us to know what Dusk test to run domain is the inside code ui is the outside",
+        '--context' => "domain or ui this will help us to know what Dusk test to generate; domain is the inside code, ui is the outside",
         "relative_feature_file_path" => "The path to the file for example tests/features/foo.feature"
     ]
 );
@@ -83,9 +83,9 @@ $app->command('run [--context=] relative_feature_file_path', function (
 
 })->defaults([
     'context' => "domain"
-])->descriptions("This will stuff out your feature into a Dusk Test file",
+])->descriptions("This will execute the specified tests ",
     [
-        '--context' => "domain or ui this will help us to know what Dusk test to run domain is the inside code ui is the outside",
+        '--context' => "domain or ui this will help us to know what Dusk test to run; domain is the inside code, ui is the outside",
         "relative_feature_file_path" => "The path to the file for example tests/features/foo.feature"
     ]
 );


### PR DESCRIPTION
## Description
- typo: `stuff` vs `stub`
- description for `run` was incorrect: was same as for `initialize`
- added some punctuation to the `context` explanation, just for readability

## How has this been tested?
- Tested from command line
- Incidentally, from PHP 7.2 ... however, that context is irrelevant for these typos

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
